### PR TITLE
Clamp map dragging to container bounds

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import { ComposableMap, Geographies, Geography, ZoomableGroup } from "react-simple-maps";
-import { geoEqualEarth, geoPath } from "d3-geo";
+import { geoEqualEarth } from "d3-geo";
 import { ArrowLeftRight, Search, Info } from "lucide-react";
 
 // ---------------------------------------------------------------------------
@@ -875,30 +875,13 @@ export default function App() {
     return projection;
   }, [worldFC, mapW, mapH]);
 
-  const mapBounds = useMemo(() => {
-    try {
-      if (worldFC && mapProjection) {
-        const path = geoPath(mapProjection);
-        return path.bounds(worldFC);
-      }
-    } catch {
-      // ignore projection errors and fall back to the container bounds
-    }
-    return [
+  const mapDragBounds = useMemo(
+    () => [
       [0, 0],
       [mapW, mapH],
-    ];
-  }, [worldFC, mapProjection, mapW, mapH]);
-
-  const mapDragBounds = useMemo(() => {
-    const [[minX, minY], [maxX, maxY]] = mapBounds;
-    const padX = mapW * 0.05;
-    const padY = mapH * 0.05;
-    return [
-      [minX - padX, minY - padY],
-      [maxX + padX, maxY + padY],
-    ];
-  }, [mapBounds, mapW, mapH]);
+    ],
+    [mapW, mapH]
+  );
 
   const clampCenter = useCallback(
     (coordinates, rawZoom = zoomRef.current) => {


### PR DESCRIPTION
## Summary
- clamp map dragging to the visible container so the map never exposes blank space
- simplify the map extent setup by removing the derived GeoJSON bounds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d830d946e8832f865dca6b9cd3ac3f