### PR TITLE
Fix map drag detection to allow country selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -963,11 +963,18 @@ export default function App() {
   const skipClickRef = useRef(false);
 
   const handleMoveStart = useCallback(() => {
-    draggingRef.current = true;
-    skipClickRef.current = true;
-    setIsDraggingMap(true);
-    setHoverName("");
+    draggingRef.current = false;
+    skipClickRef.current = false;
   }, []);
+
+  const handleMove = useCallback(() => {
+    if (!draggingRef.current) {
+      draggingRef.current = true;
+      setIsDraggingMap(true);
+      setHoverName("");
+    }
+    skipClickRef.current = true;
+  }, [setHoverName, setIsDraggingMap]);
 
   const handleMoveOrZoomEnd = useCallback(
     (_, position) => {
@@ -1229,6 +1236,7 @@ export default function App() {
                           zoom={zoom}
                           center={center}
                           onMoveStart={handleMoveStart}
+                          onMove={handleMove}
                           onMoveEnd={handleMoveOrZoomEnd}
                           onZoomEnd={handleMoveOrZoomEnd}
                           minZoom={1}


### PR DESCRIPTION
## Summary
- update the drag-state bookkeeping so clicks are only ignored after a real map drag
- add a ZoomableGroup move handler to mark active drags and keep hover/click interactions responsive

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d850d814bc832fa0f6598d7fb9cf61