### PR TITLE
Improve map selection highlighting

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,32 @@
 @import "tailwindcss";
+
+.map-selection-pulse {
+  pointer-events: none;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  animation: mapSelectionPulse 2.8s ease-out infinite;
+}
+
+.map-selection-pulse--a {
+  stroke: #6366f1;
+}
+
+.map-selection-pulse--b {
+  stroke: #f97316;
+}
+
+@keyframes mapSelectionPulse {
+  0% {
+    stroke-width: 1.5;
+    stroke-opacity: 0.45;
+  }
+  55% {
+    stroke-width: 11;
+    stroke-opacity: 0;
+  }
+  100% {
+    stroke-width: 11;
+    stroke-opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- switch the map selection colors to palette-friendly indigo and orange shades
- add an animated pulse outline so selected countries are easy to spot on the map
- update selection badges and list rows to use the new color scheme

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d866833b90832f846d8e238fbafe37